### PR TITLE
Backport mips64 fix from upstream meson

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -469,6 +469,7 @@ def machine_info_can_run(machine_info: MachineInfo):
     return \
         (machine_info.cpu_family == true_build_cpu_family) or \
         ((true_build_cpu_family == 'x86_64') and (machine_info.cpu_family == 'x86')) or \
+        ((true_build_cpu_family == 'mips64') and (machine_info.cpu_family == 'mips')) or \
         ((true_build_cpu_family == 'aarch64') and (machine_info.cpu_family == 'arm'))
 
 class Environment:

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -343,7 +343,7 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
     # MIPS64 is able to run MIPS32 code natively, so there is a chance that
     # such mixture mentioned above exists.
     elif trial == 'mips64':
-        if not any_compiler_has_define(compilers, '__mips64'):
+        if compilers and not any_compiler_has_define(compilers, '__mips64'):
             trial = 'mips'
 
     if trial not in known_cpu_families:
@@ -383,7 +383,7 @@ def detect_cpu(compilers: CompilersDict) -> str:
         if '64' not in trial:
             trial = 'mips'
         else:
-            if not any_compiler_has_define(compilers, '__mips64'):
+            if compilers and not any_compiler_has_define(compilers, '__mips64'):
                 trial = 'mips'
             else:
                 trial = 'mips64'

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1596,16 +1596,18 @@ class InternalTests(unittest.TestCase):
             ('aarch64_be', 'aarch64'),
         ]
 
+        cc = ClangCCompiler([], [], 'fake', MachineChoice.HOST, False, mock.Mock())
+
         with mock.patch('mesonbuild.environment.any_compiler_has_define', mock.Mock(return_value=False)):
             for test, expected in cases:
                 with self.subTest(test, has_define=False), mock_trial(test):
-                    actual = mesonbuild.environment.detect_cpu_family({})
+                    actual = mesonbuild.environment.detect_cpu_family({'c': cc})
                     self.assertEqual(actual, expected)
 
         with mock.patch('mesonbuild.environment.any_compiler_has_define', mock.Mock(return_value=True)):
             for test, expected in [('x86_64', 'x86'), ('aarch64', 'arm'), ('ppc', 'ppc64'), ('mips64', 'mips64')]:
                 with self.subTest(test, has_define=True), mock_trial(test):
-                    actual = mesonbuild.environment.detect_cpu_family({})
+                    actual = mesonbuild.environment.detect_cpu_family({'c': cc})
                     self.assertEqual(actual, expected)
 
     def test_detect_cpu(self) -> None:
@@ -1633,16 +1635,18 @@ class InternalTests(unittest.TestCase):
             ('aarch64_be', 'aarch64'),
         ]
 
+        cc = ClangCCompiler([], [], 'fake', MachineChoice.HOST, False, mock.Mock())
+
         with mock.patch('mesonbuild.environment.any_compiler_has_define', mock.Mock(return_value=False)):
             for test, expected in cases:
                 with self.subTest(test, has_define=False), mock_trial(test):
-                    actual = mesonbuild.environment.detect_cpu({})
+                    actual = mesonbuild.environment.detect_cpu({'c': cc})
                     self.assertEqual(actual, expected)
 
         with mock.patch('mesonbuild.environment.any_compiler_has_define', mock.Mock(return_value=True)):
             for test, expected in [('x86_64', 'i686'), ('aarch64', 'arm'), ('ppc', 'ppc64'), ('mips64', 'mips64')]:
                 with self.subTest(test, has_define=True), mock_trial(test):
-                    actual = mesonbuild.environment.detect_cpu({})
+                    actual = mesonbuild.environment.detect_cpu({'c': cc})
                     self.assertEqual(actual, expected)
 
     def test_interpreter_unpicklable(self) -> None:

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1610,6 +1610,16 @@ class InternalTests(unittest.TestCase):
                     actual = mesonbuild.environment.detect_cpu_family({'c': cc})
                     self.assertEqual(actual, expected)
 
+        # machine_info_can_run calls detect_cpu_family with no compilers at all
+        with mock.patch(
+            'mesonbuild.environment.any_compiler_has_define',
+            mock.Mock(side_effect=AssertionError('Should not be called')),
+        ):
+            for test, expected in [('mips64', 'mips64')]:
+                with self.subTest(test, has_compiler=False), mock_trial(test):
+                    actual = mesonbuild.environment.detect_cpu_family({})
+                    self.assertEqual(actual, expected)
+
     def test_detect_cpu(self) -> None:
 
         @contextlib.contextmanager
@@ -1647,6 +1657,15 @@ class InternalTests(unittest.TestCase):
             for test, expected in [('x86_64', 'i686'), ('aarch64', 'arm'), ('ppc', 'ppc64'), ('mips64', 'mips64')]:
                 with self.subTest(test, has_define=True), mock_trial(test):
                     actual = mesonbuild.environment.detect_cpu({'c': cc})
+                    self.assertEqual(actual, expected)
+
+        with mock.patch(
+            'mesonbuild.environment.any_compiler_has_define',
+            mock.Mock(side_effect=AssertionError('Should not be called')),
+        ):
+            for test, expected in [('mips64', 'mips64')]:
+                with self.subTest(test, has_compiler=False), mock_trial(test):
+                    actual = mesonbuild.environment.detect_cpu({})
                     self.assertEqual(actual, expected)
 
     def test_interpreter_unpicklable(self) -> None:


### PR DESCRIPTION
Otherwise native compile on mips64 is misdetected as a cross-compile.

https://github.com/mesonbuild/meson/pull/12080