### PR TITLE
Stop using removed `importlib.resources` functions on Python >=3.13

### DIFF
--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import functools, json, os, textwrap
 from pathlib import Path
+import sys
 import typing as T
 
 from .. import mesonlib, mlog
@@ -110,8 +111,13 @@ class BasicPythonExternalProgram(ExternalProgram):
         # Sanity check, we expect to have something that at least quacks in tune
 
         import importlib.resources
+        if sys.version_info >= (3, 13):
+            traversable = importlib.resources.files('mesonbuild.scripts').joinpath('python_info.py')
+            context_mgr = importlib.resources.as_file(traversable)
+        else:
+            context_mgr = importlib.resources.path('mesonbuild.scripts', 'python_info.py')
 
-        with importlib.resources.path('mesonbuild.scripts', 'python_info.py') as f:
+        with context_mgr as f:
             cmd = self.get_command() + [str(f)]
             p, stdout, stderr = mesonlib.Popen_safe(cmd)
 

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-import copy, json, os, shutil
+import copy, json, os, shutil, sys
 import typing as T
 
 from . import ExtensionModule, ModuleInfo
@@ -329,7 +329,10 @@ class PythonModule(ExtensionModule):
         import importlib.resources
         pycompile = os.path.join(self.interpreter.environment.get_scratch_dir(), 'pycompile.py')
         with open(pycompile, 'wb') as f:
-            f.write(importlib.resources.read_binary('mesonbuild.scripts', 'pycompile.py'))
+            if sys.version_info >= (3, 13):
+                f.write(importlib.resources.files('mesonbuild.scripts').joinpath('pycompile.py').read_bytes())
+            else:
+                f.write(importlib.resources.read_binary('mesonbuild.scripts', 'pycompile.py'))
 
         for i in self.installations.values():
             if isinstance(i, PythonExternalProgram) and i.run_bytecompile[i.info['version']]:


### PR DESCRIPTION
This may not be necessary if the removal in CPython gets reverted, but it gets NumPy building with CPython 3.13.0a1 and current `main`. So may as well work around it as long as we have a vendored Meson and I have the band aid (submitted upstream as https://github.com/mesonbuild/meson/pull/12402). That way folks who care can identify work on issues in NumPy with CPython dev versions.