### PR TITLE
BUG: fix macOS version checks so things work in very old versions

### DIFF
--- a/mesonbuild/dependencies/blas_lapack.py
+++ b/mesonbuild/dependencies/blas_lapack.py
@@ -742,12 +742,15 @@ class AccelerateSystemDependency(BLASLAPACKMixin, SystemDependency):
             self.detect(kwargs)
 
     def check_macOS_recent_enough(self) -> bool:
-        # We need the SDK to be >=13.3 (meaning at least XCode 14.3)
-        cmd = ['xcrun', '-sdk', 'macosx', '--show-sdk-version']
-        sdk_version = subprocess.run(cmd, capture_output=True, check=True, text=True).stdout.strip()
         macos_version = platform.mac_ver()[0]
         deploy_target = os.environ.get('MACOSX_DEPLOYMENT_TARGET', macos_version)
-        return sdk_version >= '13.3' and deploy_target >= '13.3'
+        if not mesonlib.version_compare(deploy_target, '>=13.3'):
+            return False
+
+        # We also need the SDK to be >=13.3 (meaning at least XCode 14.3)
+        cmd = ['xcrun', '-sdk', 'macosx', '--show-sdk-version']
+        sdk_version = subprocess.run(cmd, capture_output=True, check=True, text=True).stdout.strip()
+        return mesonlib.version_compare(sdk_version, '>=13.3')
 
     def detect(self, kwargs: T.Dict[str, T.Any]) -> None:
         from .framework import ExtraFrameworkDependency


### PR DESCRIPTION
The two things fixed here:
- `xcrun` isn't available on very old versions (MacPorts still supports 10.5/10.6)
- Version comparison is done correctly now with `mesonlib.version_compare`

See https://github.com/numpy/numpy/issues/25406 for the bug report.