### PR TITLE
Incorporate MinGW detection fix

### DIFF
--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -249,14 +249,15 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
             self.is_found = True
 
     def get_windows_python_arch(self) -> T.Optional[str]:
-        if self.platform == 'mingw':
-            pycc = self.variables.get('CC')
-            if pycc.startswith('x86_64'):
+        if self.platform.startswith('mingw'):
+            if 'x86_64' in self.platform:
                 return 'x86_64'
-            elif pycc.startswith(('i686', 'i386')):
+            elif 'i686' in self.platform:
                 return 'x86'
+            elif 'aarch64' in self.platform:
+                return 'aarch64'
             else:
-                mlog.log(f'MinGW Python built with unknown CC {pycc!r}, please file a bug')
+                mlog.log(f'MinGW Python built with unknown platform {self.platform!r}, please file a bug')
                 return None
         elif self.platform == 'win32':
             return 'x86'
@@ -311,7 +312,7 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
                             '''))
             # base_prefix to allow for virtualenvs.
             lib = Path(self.variables.get('base_prefix')) / libpath
-        elif self.platform == 'mingw':
+        elif self.platform.startswith('mingw'):
             if self.static:
                 libname = self.variables.get('LIBRARY')
             else:


### PR DESCRIPTION
As discussed in https://github.com/numpy/numpy/issues/25518.

python: fix mingw python detection code in case pkg-config isn't avai…

The code assumed that sysconfig.get_platform() returns "mingw" for mingw Python, but that's no longer the case for 2.5 years now, as it now only starts with "mingw" and contains further information like the arch and other ABI relevant things to avoid conflicts.

This updates the detection code to the current status quo. mingw Python only documents right now that it starts with "mingw", and none of that arch stuff, but it's unlikely that this will change, and this looks less error prone than looking at CC.

Fixes Meson issue 12547

(cherry picked from commit 6eee9e7c0c91fecb26676c05898c54d010b5e1c4)