### PR TITLE
PR: Add `CYTHON` environment variable to `mesonbuild.envconfig.ENV_VAR_COMPILER_MAP` attribute.

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -98,6 +98,7 @@ ENV_VAR_COMPILER_MAP: T.Mapping[str, str] = {
     'c': 'CC',
     'cpp': 'CXX',
     'cs': 'CSC',
+    'cython': 'CYTHON',
     'd': 'DC',
     'fortran': 'FC',
     'objc': 'OBJC',


### PR DESCRIPTION
Hello,

The `CYTHON` key is required for custom build pipelines defining the build environment with variables.

Cheers,

Thomas