### PR TITLE
Add patches for cross-compilation

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -568,7 +568,8 @@ class Backend:
         else:
             extra_paths = []
 
-        if self.environment.need_exe_wrapper(exe_for_machine):
+        is_cross_built = not self.environment.machines.matches_build_machine(exe_for_machine)
+        if is_cross_built and self.environment.need_exe_wrapper():
             if not self.environment.has_exe_wrapper():
                 msg = 'An exe_wrapper is needed but was not found. Please define one ' \
                       'in cross file and check the command and/or add it to PATH.'

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -551,7 +551,7 @@ class CudaCompiler(Compiler):
         flags += self.get_ccbin_args(env.coredata.options)
 
         # If cross-compiling, we can't run the sanity check, only compile it.
-        if env.need_exe_wrapper(self.for_machine) and not env.has_exe_wrapper():
+        if self.is_cross and not env.has_exe_wrapper():
             # Linking cross built apps is painful. You can't really
             # tell if you should use -nostdlib or not and for example
             # on OSX the compiler binary is the same but you need
@@ -573,7 +573,7 @@ class CudaCompiler(Compiler):
             raise EnvironmentException(f'Compiler {self.name_string()} cannot compile programs.')
 
         # Run sanity check (if possible)
-        if env.need_exe_wrapper(self.for_machine):
+        if self.is_cross:
             if not env.has_exe_wrapper():
                 return
             else:

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -447,7 +447,7 @@ class DCompiler(Compiler):
         compile_cmdlist = self.exelist + self.get_output_args(output_name) + self._get_target_arch_args() + [source_name]
 
         # If cross-compiling, we can't run the sanity check, only compile it.
-        if environment.need_exe_wrapper(self.for_machine) and not environment.has_exe_wrapper():
+        if self.is_cross and not environment.has_exe_wrapper():
             compile_cmdlist += self.get_compile_only_args()
 
         pc = subprocess.Popen(compile_cmdlist, cwd=work_dir)
@@ -455,7 +455,7 @@ class DCompiler(Compiler):
         if pc.returncode != 0:
             raise EnvironmentException('D compiler %s cannot compile programs.' % self.name_string())
 
-        if environment.need_exe_wrapper(self.for_machine):
+        if self.is_cross:
             if not environment.has_exe_wrapper():
                 # Can't check if the binaries run so we have to assume they do
                 return

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -1161,7 +1161,8 @@ def detect_d_compiler(env: 'Environment', for_machine: MachineChoice) -> Compile
 
             return cls(
                 exelist, version, for_machine, info, arch,
-                full_version=full_version, linker=linker, version_output=out)
+                full_version=full_version, linker=linker,
+                is_cross=is_cross, version_output=out)
         elif 'gdc' in out:
             cls = d.GnuDCompiler
             linker = guess_nix_linker(env, exelist, cls, version, for_machine)

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -278,7 +278,7 @@ class CLikeCompiler(Compiler):
         mode = CompileCheckMode.LINK
         if self.is_cross:
             binname += '_cross'
-            if environment.need_exe_wrapper(self.for_machine) and not environment.has_exe_wrapper():
+            if not environment.has_exe_wrapper():
                 # Linking cross built C/C++ apps is painful. You can't really
                 # tell if you should use -nostdlib or not and for example
                 # on OSX the compiler binary is the same but you need
@@ -308,7 +308,7 @@ class CLikeCompiler(Compiler):
         if pc.returncode != 0:
             raise mesonlib.EnvironmentException(f'Compiler {self.name_string()} cannot compile programs.')
         # Run sanity check
-        if environment.need_exe_wrapper(self.for_machine):
+        if self.is_cross:
             if not environment.has_exe_wrapper():
                 # Can't check if the binaries run so we have to assume they do
                 return

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -86,7 +86,7 @@ class RustCompiler(Compiler):
         if pc.returncode != 0:
             raise EnvironmentException(f'Rust compiler {self.name_string()} cannot compile programs.')
         self._native_static_libs(work_dir, source_name)
-        if environment.need_exe_wrapper(self.for_machine):
+        if self.is_cross:
             if not environment.has_exe_wrapper():
                 # Can't check if the binaries run so we have to assume they do
                 return

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -505,6 +505,7 @@ def machine_info_can_run(machine_info: MachineInfo):
     if machine_info.system != detect_system():
         return False
     true_build_cpu_family = detect_cpu_family({})
+    assert machine_info.cpu_family is not None, 'called on incomplete machine_info'
     return \
         (machine_info.cpu_family == true_build_cpu_family) or \
         ((true_build_cpu_family == 'x86_64') and (machine_info.cpu_family == 'x86')) or \


### PR DESCRIPTION
For https://github.com/numpy/numpy/issues/27044; as the version currently vendored in https://github.com/mesonbuild/meson/issues/13403 runs into. Backport the relevant patch (+fix-ups), plus a precursor that is itself not relevant to us (it's for D), but avoids having to do conflict-resolution.

This corresponds to the [patches](https://github.com/conda-forge/numpy-feedstock/blob/bb811d307537bc045c008b235493fd08850c4899/recipe/patches) we're also currently carrying in the numpy-feedstock in conda-forge.