### PR TITLE
linkers: Fix linker detection with clang on Solaris

### DIFF
--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -177,27 +177,6 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
             v = search_version(o)
 
         linker = linkers.LLVMDynamicLinker(compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)
-    # detect xtools first, bug #10805
-    elif 'xtools-' in o.split('\n', maxsplit=1)[0]:
-        xtools = o.split(' ', maxsplit=1)[0]
-        v = xtools.split('-', maxsplit=2)[1]
-        linker = linkers.AppleDynamicLinker(compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)
-    # First might be apple clang, second is for real gcc, the third is icc.
-    # Note that "ld: unknown option: " sometimes instead is "ld: unknown options:".
-    elif e.endswith('(use -v to see invocation)\n') or 'macosx_version' in e or 'ld: unknown option' in e:
-        if isinstance(comp_class.LINKER_PREFIX, str):
-            cmd = compiler + [comp_class.LINKER_PREFIX + '-v'] + extra_args
-        else:
-            cmd = compiler + comp_class.LINKER_PREFIX + ['-v'] + extra_args
-        _, newo, newerr = Popen_safe_logged(cmd, msg='Detecting Apple linker via')
-
-        for line in newerr.split('\n'):
-            if 'PROJECT:ld' in line or 'PROJECT:dyld' in line:
-                v = line.split('-')[1]
-                break
-        else:
-            __failed_to_detect_linker(compiler, check_args, o, e)
-        linker = linkers.AppleDynamicLinker(compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)
     elif 'GNU' in o or 'GNU' in e:
         gnu_cls: T.Type[GnuDynamicLinker]
         # this is always the only thing on stdout, except for swift
@@ -227,6 +206,33 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
         linker = linkers.AIXDynamicLinker(
             compiler, for_machine, comp_class.LINKER_PREFIX, override,
             version=search_version(e))
+    elif o.startswith('zig ld'):
+        linker = linkers.ZigCCDynamicLinker(
+            compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)
+    # detect xtools first, bug #10805
+    elif 'xtools-' in o.split('\n', maxsplit=1)[0]:
+        xtools = o.split(' ', maxsplit=1)[0]
+        v = xtools.split('-', maxsplit=2)[1]
+        linker = linkers.AppleDynamicLinker(compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)
+    # detect linker on MacOS - must be after other platforms because the
+    # "(use -v to see invocation)" will match clang on other platforms,
+    # but the rest of the checks will fail and call __failed_to_detect_linker.
+    # First might be apple clang, second is for real gcc, the third is icc.
+    # Note that "ld: unknown option: " sometimes instead is "ld: unknown options:".
+    elif e.endswith('(use -v to see invocation)\n') or 'macosx_version' in e or 'ld: unknown option' in e:
+        if isinstance(comp_class.LINKER_PREFIX, str):
+            cmd = compiler + [comp_class.LINKER_PREFIX + '-v'] + extra_args
+        else:
+            cmd = compiler + comp_class.LINKER_PREFIX + ['-v'] + extra_args
+        _, newo, newerr = Popen_safe_logged(cmd, msg='Detecting Apple linker via')
+
+        for line in newerr.split('\n'):
+            if 'PROJECT:ld' in line or 'PROJECT:dyld' in line:
+                v = line.split('-')[1]
+                break
+        else:
+            __failed_to_detect_linker(compiler, check_args, o, e)
+        linker = linkers.AppleDynamicLinker(compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)
     else:
         __failed_to_detect_linker(compiler, check_args, o, e)
     return linker

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1127,6 +1127,8 @@ class AllPlatformTests(BasePlatformTests):
                     # ld-like linker of link.exe-like linker (usually the
                     # former for msys2, the latter otherwise)
                     self.assertIsInstance(cc.linker, (linkers.MSVCDynamicLinker, linkers.GnuLikeDynamicLinkerMixin))
+                elif is_sunos():
+                    self.assertIsInstance(cc.linker, (linkers.SolarisDynamicLinker, linkers.GnuLikeDynamicLinkerMixin))
                 else:
                     self.assertIsInstance(cc.linker, linkers.GnuLikeDynamicLinkerMixin)
             if isinstance(cc, intel):


### PR DESCRIPTION
Incorporate https://github.com/mesonbuild/meson/commit/b7ce7c2d39cb537d9158e24e458ee5ce293a7bd3 in NumPy's fork, in order to address https://github.com/numpy/numpy/issues/27531.