### PR TITLE
Add framework linking for iOS builds.

### DIFF
--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -349,8 +349,14 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
         SystemDependency.__init__(self, name, environment, kwargs)
         _PythonDependencyBase.__init__(self, installation, kwargs.get('embed', False))
 
-        # match pkg-config behavior
-        if self.link_libpython:
+        # For most platforms, match pkg-config behavior. iOS is a special case;
+        # check for that first, so that check takes priority over
+        # `link_libpython` (which *shouldn't* be set, but just in case)
+        if self.platform.startswith('ios-'):
+            # iOS doesn't use link_libpython - it links with the *framework*.
+            self.link_args = ['-framework', 'Python', '-F', self.variables.get('prefix')]
+            self.is_found = True
+        elif self.link_libpython:
             # link args
             if mesonlib.is_windows():
                 self.find_libpy_windows(environment, limited_api=False)


### PR DESCRIPTION
A backport of mesonbuild/meson#14541 into the NumPy version of meson. That PR has been merged into master, for release in Meson 1.9.

When building for iOS, and Python is a dependency, linking against the Python framework is required. This is done [automatically for all the standard library modules](https://github.com/python/cpython/blob/v3.14.0a7/configure.ac#L3459-L3463).

This behavior differs from macOS. On macOS, binary modules are linked with `-undefined dynamic_lookup`; that option is marked as deprecated for the iOS compiler, so it can't be used.

It also differs from Unix platforms that link against `libPython` - the link must be against the framework, not the library, as iOS doesn't allow "normal" dynamic library linking. As a result, existing `link_libpython` can't be used.
