### PR TITLE
Use base_prefix, not prefix for iOS framework linking.

### DIFF
--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -354,7 +354,7 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
         # `link_libpython` (which *shouldn't* be set, but just in case)
         if self.platform.startswith('ios-'):
             # iOS doesn't use link_libpython - it links with the *framework*.
-            self.link_args = ['-framework', 'Python', '-F', self.variables.get('prefix')]
+            self.link_args = ['-framework', 'Python', '-F', self.variables.get('base_prefix')]
             self.is_found = True
         elif self.link_libpython:
             # link args


### PR DESCRIPTION
Backport of mesonbuild/meson#14849.

Modifies iOS linking with the Python framework to use `sys.base_prefix`, rather than `sys.prefix`.

Outside of a venv, `sys.prefix` and `sys.base_prefix` are the same. However, if you're using a virtual environment. `sys.prefix` points at the location of the virtual environment, not the location of the iOS binaries. `sys.base_prefix` should be used to ensure that you're always referencing the underlying install location, not the venv location.

